### PR TITLE
Encoding spaces in image filename

### DIFF
--- a/vsphere/PCF-NSX-Cookbook.md
+++ b/vsphere/PCF-NSX-Cookbook.md
@@ -46,7 +46,7 @@ The NSX Edges will have an interface in each port group used by PCF as well as a
 
 Example:
 
-![Port Groups](../static/vsphere/images/PCF RefArch vSphere NSX v4 Port Groups.png)
+![Port Groups](../static/vsphere/images/PCF%20RefArch%20vSphere%20NSX%20v4%20Port%20Groups.png)
 
   The following is an example of a network architecture deployment.
 


### PR DESCRIPTION
Adding spaces so diagram is rendered in the markdown.